### PR TITLE
Update tutorial to emit OTLP-formatted traces

### DIFF
--- a/doc/tutorial.adoc
+++ b/doc/tutorial.adoc
@@ -141,7 +141,6 @@ Ensure the file is placed in the project root directory (the same directory as `
 
  :aliases {:otel {:jvm-opts ["-javaagent:opentelemetry-javaagent.jar"
                              "-Dotel.resource.attributes=service.name=counter-service"
-                             "-Dotel.traces.exporter=jaeger"
                              "-Dotel.metrics.exporter=none"]}}}
 ----
 


### PR DESCRIPTION
From https://www.jaegertracing.io/docs/1.6/client-libraries/#deprecating-jaeger-clients

> Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native OpenTelemetry Protocol (OTLP).

(Thanks for taking the time to write the tutorial!)