### PR TITLE
Type hint return value of otel/get-text-map-propagator

### DIFF
--- a/clj-otel-api/src/steffan_westcott/clj_otel/api/otel.clj
+++ b/clj-otel-api/src/steffan_westcott/clj_otel/api/otel.clj
@@ -47,7 +47,7 @@
 (defn get-text-map-propagator
   "Gets the text map propagator of an `OpenTelemetry` instance `open-telemetry`
    or the default `OpenTelemetry` instance."
-  ([]
+  (^TextMapPropagator []
    (get-text-map-propagator (get-default-otel!)))
-  ([^OpenTelemetry open-telemetry]
+  (^TextMapPropagator [^OpenTelemetry open-telemetry]
    (.getTextMapPropagator (.getPropagators open-telemetry))))


### PR DESCRIPTION
The return value of `steffan-westcott.clj-otel.api.otel/get-text-map-propagator` is most likely used in a call to `(.inject propagator ,,,)`, where the type hint is helpful.