### PR TITLE
Convert TextMapGetter key to lower-case

### DIFF
--- a/clj-otel-api/src/steffan_westcott/clj_otel/context.clj
+++ b/clj-otel-api/src/steffan_westcott/clj_otel/context.clj
@@ -146,7 +146,7 @@
      (keys [_ carrier]
        (keys carrier))
      (get [_ carrier key]
-       (some-> (get carrier key)
+       (some-> (get carrier (str/lower-case key))
                (str/split #",")
                first
                str/trim))))


### PR DESCRIPTION
Certain propagators submit .get requests using camel-case keys.

For instance, the B3Propagator looks for headers such as 'X-B3-TraceId'.

Since HTTP tends to favor/enforce lower-case, there are cases where there is an impedance mismatch, and the get will fail.  This mismatch materializes as a failure to connect to the propagated context.  For example, the headers arriving over my HTTP/2 connection look like "x-b3-traceid" and are missed by the current TextMapGetter implementation.

I am unsure of the best fix here.  The current proposal assumes that the headers are already in lower-case format.  There are other places within the clj-otel codebase where this is likewise assumed, so I went in this direction for consistency.

For an example, see https://github.com/ghaskins/clj-otel/blob/28f9be09fe870243db6f7a270473975c772deac6/clj-otel-api/src/steffan_westcott/clj_otel/api/trace/http.clj#L44

This code assumes that headers like "host" and "x-forwarded-for" are already in lower-case form.

We should consider whether this is good enough or should be more proactive and either normalize the headers or use other case-insensitive approaches.  The effort to clean this up can probably be undertaken as a follow-up patch.