### PR TITLE
Remove dashes to underscores normalization from http header attribute keys

### DIFF
--- a/clj-otel-api/src/steffan_westcott/clj_otel/api/trace/http.clj
+++ b/clj-otel-api/src/steffan_westcott/clj_otel/api/trace/http.clj
@@ -26,7 +26,7 @@
   [init prefix captured-headers headers]
   (persistent! (reduce (fn [m header-name]
                          (if-let [v (get headers header-name)]
-                           (assoc! m (str prefix (str/replace header-name \- \_)) [v])
+                           (assoc! m (str prefix header-name) [v])
                            m))
                        (transient init)
                        captured-headers)))


### PR DESCRIPTION
cf. https://github.com/open-telemetry/semantic-conventions/pull/369