### PR TITLE
Add `:sdk-builder-customizer` option to `init-otel-sdk!`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,7 +32,9 @@ This enables a logging library to emit log records.
 The Logs API is not intended for use by an application or general library.
 - [ADD] `LoggerProvider` support in programmatic configuration of the SDK.
 - [ADD] By default, populate span attribute for source code column number.
-- [ADD] New option `:prop-overrides` on `steffan-westcott.clj-otel.sdk.autoconfigure/init-otel-sdk!` to override default config values.
+- [ADD] New options on `steffan-westcott.clj-otel.sdk.autoconfigure/init-otel-sdk!`:
+* `:prop-overrides` to override default config values
+* `:sdk-builder-customizer` to further customize the autoconfigured SDK beyond the provided options
 - Bump deps
 * [MAINT] OpenTelemetry `1.54.1`, instrumentation `2.20.1`
 

--- a/clj-otel-sdk-extension-autoconfigure/src/steffan_westcott/clj_otel/sdk/autoconfigure.clj
+++ b/clj-otel-sdk-extension-autoconfigure/src/steffan_westcott/clj_otel/sdk/autoconfigure.clj
@@ -24,17 +24,19 @@
    |`:set-as-default`        | If true, sets the configured SDK instance as the default `OpenTelemetry` instance declared and used by `clj-otel` (default: `true`).
    |`:set-as-global`         | If true, sets the configured SDK instance as the global `OpenTelemetry` instance declared by Java OpenTelemetry (default: `false`).
    |`:register-shutdown-hook`| If true, registers a JVM shutdown hook to close the configured SDK instance (default: `true`).
-   |`:prop-overrides`        | fn that takes io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties and returns a string map of config property names and values to override defaults. Config property lookup precedence is: system property > env var > override > default."
+   |`:prop-overrides`        | fn that takes io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties and returns a string map of config property names and values to override defaults. Config property lookup precedence is: system property > env var > override > default.
+   |`:sdk-builder-customizer`| fn that takes io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder and returns it, allowing further customization of the builder before building the SDK instance."
   (^OpenTelemetrySdk [] (init-otel-sdk! {}))
   (^OpenTelemetrySdk
-   [{:keys [set-as-default set-as-global register-shutdown-hook prop-overrides]
+   [{:keys [set-as-default set-as-global register-shutdown-hook prop-overrides sdk-builder-customizer]
      :or   {set-as-default         true
             set-as-global          false
             register-shutdown-hook true}}]
    (let [builder  (cond-> (AutoConfiguredOpenTelemetrySdk/builder)
                     set-as-global  (.setResultAsGlobal)
                     (not register-shutdown-hook) (.disableShutdownHook)
-                    prop-overrides (.addPropertiesCustomizer (util/function prop-overrides)))
+                    prop-overrides (.addPropertiesCustomizer (util/function prop-overrides))
+                    sdk-builder-customizer (sdk-builder-customizer))
          auto-sdk (.build builder)
          sdk      (.getOpenTelemetrySdk auto-sdk)]
      (when set-as-default


### PR DESCRIPTION
Add an option to let the user take full advantage of [autoconfigured SDK programmatic customization](https://opentelemetry.io/docs/languages/java/configuration/#programmatic-customization).

Example & test:

```diff
diff --git a/examples/square-app/src/example/square_app.clj b/examples/square-app/src/example/square_app.clj
index 0738f376..fc8541da 100644
--- a/examples/square-app/src/example/square_app.clj
+++ b/examples/square-app/src/example/square_app.clj
@@ -6,7 +6,7 @@
             [steffan-westcott.clj-otel.instrumentation.runtime-telemetry-java8 :as
              runtime-telemetry]
             [steffan-westcott.clj-otel.sdk.autoconfigure :as autoconfig])
-  (:import (io.opentelemetry.instrumentation.log4j.appender.v2_17 OpenTelemetryAppender)))
+  (:import (io.opentelemetry.sdk.autoconfigure AutoConfiguredOpenTelemetrySdkBuilder)))

 (defonce ^{:doc "Delay containing counter that records the number of squares calculated."}
@@ -32,8 +32,12 @@
 (defn init-otel
   "Initialises autoconfigured OpenTelemetry and registers JVM runtime metrics."
   []
-  (let [sdk (autoconfig/init-otel-sdk!)]
-    (OpenTelemetryAppender/install sdk))
+  (let [sdk (autoconfig/init-otel-sdk! {:sdk-builder-customizer
+                                        (fn [^AutoConfiguredOpenTelemetrySdkBuilder b]
+                                          (.addMetricExporterCustomizer b (fn [me _config-properties]
+                                                                            (log/info "customized!")
+                                                                            me))
+                                          b)})])
   (runtime-telemetry/register!)
   (log/info "OpenTelemetry initialised")
   :initialised)
```