### PR TITLE
add add-attributes!

### DIFF
--- a/clj-otel-api/src/steffan_westcott/clj_otel/api/trace/span.clj
+++ b/clj-otel-api/src/steffan_westcott/clj_otel/api/trace/span.clj
@@ -295,6 +295,12 @@
    (add-span-data! {:event {:name       name
                             :attributes attributes}})))
 
+(defn add-attributes!
+  "Adds attributes to the span in the bound or current context.
+   `attrs` is a map of attributes to set on the span."
+  [attrs]
+  (add-span-data! {:attributes attrs}))
+
 (defn add-exception!
   "Adds an event describing an `exception` that is escaping a span's scope. By
    default, exception data (as per `ex-info`) are added as attributes to the


### PR DESCRIPTION
Adding `add-attributes!` function to ease adding attributes. We use wide event to track things so it's often needed to add attributes on the fly. I feel `(span/add-attributes :x 1)` will be easier than `(span/add-span-data {:attributes {:x 1}})`. 

What do you think? :) 